### PR TITLE
Update Discord domain and snowflake length

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -10,7 +10,7 @@ Once a user has voted, they will be given a special `Voted` role, which by defau
 
 ## Adding The Bot
 
-You can invite the bot to your server by clicking [this](https://discordapp.com/api/oauth2/authorize?client_id=488844479868960791&permissions=268766288&scope=bot) link.
+You can invite the bot to your server by clicking [this](https://discord.com/api/oauth2/authorize?client_id=488844479868960791&permissions=268766288&scope=bot) link.
 
 **Note:** The bot is private, the link above is purely for reference.
 

--- a/src/main/java/com/mrkirby153/snowsgivingbot/commands/ManagementCommands.java
+++ b/src/main/java/com/mrkirby153/snowsgivingbot/commands/ManagementCommands.java
@@ -74,7 +74,7 @@ public class ManagementCommands {
                 if (display != null) {
                     emoteStr = display.getEmote();
                 }
-                if (emoteStr.matches("\\d{17,18}")) {
+                if (emoteStr.matches("\\d{17,19}")) {
                     Emote jdaEmote = shardManager.getEmoteById(emoteStr);
                     if (jdaEmote == null) {
                         return "_Emote not found_";
@@ -85,7 +85,7 @@ public class ManagementCommands {
                     return emoteStr;
                 }
             }, (value) -> {
-                Pattern pattern = Pattern.compile("\\d{17,18}");
+                Pattern pattern = Pattern.compile("\\d{17,19}");
                 Matcher m = pattern.matcher(value);
                 ConfiguredGiveawayEmote emote;
                 Emote e;

--- a/src/main/java/com/mrkirby153/snowsgivingbot/commands/slashcommands/ManagementSlashCommands.java
+++ b/src/main/java/com/mrkirby153/snowsgivingbot/commands/slashcommands/ManagementSlashCommands.java
@@ -31,7 +31,7 @@ import java.util.regex.Pattern;
 @Slf4j
 public class ManagementSlashCommands {
 
-    public static final Pattern EMOTE_PATTERN = Pattern.compile("\\d{17,18}");
+    public static final Pattern EMOTE_PATTERN = Pattern.compile("\\d{17,19}");
     private static final String TADA = "\uD83C\uDF89";
     private static final Function<String, Boolean> BOOLEAN_PARSER = (input) -> {
         String lower = input.toLowerCase();
@@ -61,7 +61,7 @@ public class ManagementSlashCommands {
                 if (obj != null) {
                     toDisplay = cge.getEmote();
                 }
-                if (toDisplay.matches("\\d{17,18}")) {
+                if (toDisplay.matches("\\d{17,19}")) {
                     Emote jdaEmote = shardManager.getEmoteById(toDisplay);
                     if (jdaEmote == null) {
                         return "__Emote Not Found__";

--- a/src/main/java/com/mrkirby153/snowsgivingbot/config/CommandConfig.java
+++ b/src/main/java/com/mrkirby153/snowsgivingbot/config/CommandConfig.java
@@ -22,7 +22,7 @@ import java.util.regex.Pattern;
 @Slf4j
 public class CommandConfig {
 
-    private static final Pattern ID_PATTERN = Pattern.compile("\\d{17,18}");
+    private static final Pattern ID_PATTERN = Pattern.compile("\\d{17,19}");
     private final PermissionService permissionManager;
     private final SettingService settingService;
     private String prefix;

--- a/src/main/java/com/mrkirby153/snowsgivingbot/services/impl/DiscordManager.java
+++ b/src/main/java/com/mrkirby153/snowsgivingbot/services/impl/DiscordManager.java
@@ -32,7 +32,7 @@ import java.util.stream.Collectors;
 public class DiscordManager implements DiscordService {
 
     private static final Pattern jumpLinkMatcher = Pattern.compile(
-        "https?://(canary\\.|ptb\\.)?discordapp.com/channels/(\\d{17,18})/(\\d{17,18})/(\\d{17,18})");
+        "https?://(canary\\.|ptb\\.)?discord.com/channels/(\\d{17,18})/(\\d{17,18})/(\\d{17,18})");
     private static final HashMap<String, String> messageChannelCache = new HashMap<>();
 
     private static final String PLAYING_STATUS = "giveaways.mrkirby153.com • %help";

--- a/src/main/java/com/mrkirby153/snowsgivingbot/services/impl/DiscordManager.java
+++ b/src/main/java/com/mrkirby153/snowsgivingbot/services/impl/DiscordManager.java
@@ -32,7 +32,7 @@ import java.util.stream.Collectors;
 public class DiscordManager implements DiscordService {
 
     private static final Pattern jumpLinkMatcher = Pattern.compile(
-        "https?://(canary\\.|ptb\\.)?discord.com/channels/(\\d{17,18})/(\\d{17,18})/(\\d{17,18})");
+        "https?://(canary\\.|ptb\\.)?discord.com/channels/(\\d{17,19})/(\\d{17,19})/(\\d{17,19})");
     private static final HashMap<String, String> messageChannelCache = new HashMap<>();
 
     private static final String PLAYING_STATUS = "giveaways.mrkirby153.com • %help";

--- a/src/main/java/com/mrkirby153/snowsgivingbot/services/impl/GiveawayManager.java
+++ b/src/main/java/com/mrkirby153/snowsgivingbot/services/impl/GiveawayManager.java
@@ -424,7 +424,7 @@ public class GiveawayManager implements GiveawayService {
     private List<String> generateEndMessage(GiveawayEntity entity, List<String> winners,
         boolean includeMsgLink) {
         String msgLink = String
-            .format("<https://discordapp.com/channels/%s/%s/%s>", entity.getGuildId(),
+            .format("<https://discord.com/channels/%s/%s/%s>", entity.getGuildId(),
                 entity.getChannelId(), entity.getMessageId());
 
         if (winners.size() == 0) {

--- a/src/main/java/com/mrkirby153/snowsgivingbot/services/impl/GiveawayManager.java
+++ b/src/main/java/com/mrkirby153/snowsgivingbot/services/impl/GiveawayManager.java
@@ -121,7 +121,7 @@ public class GiveawayManager implements GiveawayService {
         giveawaysEndedCounter = meterRegistry.counter("giveaway_ended");
         runningGiveawayGauge = meterRegistry.gauge("running_giveaways", new AtomicLong(0));
 
-        if (emote.matches("\\d{17,18}")) {
+        if (emote.matches("\\d{17,19}")) {
             emoji = null;
             custom = true;
             emoteId = emote;

--- a/src/main/java/com/mrkirby153/snowsgivingbot/web/controller/GiveawayController.java
+++ b/src/main/java/com/mrkirby153/snowsgivingbot/web/controller/GiveawayController.java
@@ -30,7 +30,7 @@ import java.util.regex.Pattern;
 @AllArgsConstructor
 public class GiveawayController {
 
-    private static final Pattern snowflakePattern = Pattern.compile("\\d{17,18}");
+    private static final Pattern snowflakePattern = Pattern.compile("\\d{17,19}");
     private final WebGiveawayService giveawayService;
     private final ShardManager shardManager;
     private final LoadingCache<String, ServerDto> dtoCache = CacheBuilder.newBuilder()


### PR DESCRIPTION
This pull request updates the domain for message links, from `discordapp.com` to `discord.com` (the CDN was not affected by the change) as well as the length of snowflake matching because they will reach 19 characters very soon